### PR TITLE
docs: expand quick start guidance in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,51 @@ Install dependencies:
 ```bash
 pip install numpy pandas scipy statsmodels matplotlib seaborn pyranges gseapy
 conda install -c bioconda macs2 deeptools
+```
+
+---
+
+## 🧪 Quick start
+
+1. Prepare a sample sheet (`samples.tsv`) describing your BAM files and optional peak calls.
+2. Run the pipeline with `python chipdiff.py --metadata samples.tsv --output-dir results`.
+3. Inspect the figures and result tables written to the `results/` directory.
+
+### Sample sheet format
+
+The sheet can be tab- or comma-delimited and must include the columns `sample`, `condition`, and `bam`. Optional columns allow you to reference pre-called peaks.
+
+| sample | condition | bam             | peaks                 | peak_type |
+|--------|-----------|-----------------|-----------------------|-----------|
+| S1     | treated   | data/S1.bam     | data/S1_summits.bed   | summit    |
+| S2     | treated   | data/S2.bam     | -                     | -         |
+| C1     | control   | data/C1.bam     | data/C1_peaks.bed     | narrow    |
+
+### Example command
+
+```bash
+python chipdiff.py \
+  --metadata samples.tsv \
+  --output-dir results \
+  --peak-dir peaks \
+  --min-overlap 2 \
+  --gtf annotations.gtf \
+  --enrichr
+```
+
+This run will call peaks (if needed), build consensus peaks across samples, compute counts, perform DESeq2-like differential analysis, optionally annotate peaks, and produce publication-ready plots.
+
+### Output overview
+
+Key files generated under `results/` include:
+
+- `counts.tsv` – consensus peak counts matrix.
+- `deseq2_like.tsv` / `mars.tsv` – differential analysis tables.
+- `plots/` – volcano, MA, correlation, and heatmap figures.
+- `metadata.json` – run configuration and provenance metadata.
+
+---
+
+## 🔧 Command reference
+
+Run `python chipdiff.py --help` to see all available options (peak calling parameters, threading, annotation, and enrichment settings).


### PR DESCRIPTION
## Summary
- add a quick start walkthrough to the README
- document sample sheet expectations, example invocation, and output artifacts
- point readers to the CLI help for additional configuration details

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68df48f8bf688327a503cfc2f639f8a2