### PR TITLE
Add ENCODE hg38 example workflow and reproducibility tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,42 @@ Key files generated under `results/` include:
 
 ---
 
+## 🧬 ENCODE hg38 2v2 example dataset
+
+To help you get started quickly, the repository ships with an end-to-end example based on a widely used ENCODE H3K27ac dataset (hg38):
+
+- **GM12878 H3K27ac** – ENCSR000AKP
+- **K562 H3K27ac** – ENCSR000AKO
+
+The scripts in `example/` orchestrate downloading the public alignments, executing the PeakForge pipeline for the 2 vs 2 comparison, repeating all four possible 1 vs 1 contrasts, and benchmarking how closely the 1 vs 1 runs reproduce the 2 vs 2 signal.
+
+1. **Prepare the inputs**
+   ```bash
+   # Prints the curl commands by default (DRY_RUN=1)
+   bash example/download_encode.sh
+
+   # Actually download the BAMs (~15 GB total)
+   DRY_RUN=0 bash example/download_encode.sh
+   ```
+   Downloads are written to `example/data/` and a manifest (`encode_manifest.tsv`) is generated alongside the tab-delimited sample sheet (`metadata.tsv`).
+
+2. **Run the complete analysis**
+   ```bash
+   bash example/run_pipeline.sh
+   ```
+   This executes the 2v2 workflow plus four one-vs-one runs, storing results in `example/results/`.
+
+3. **Inspect reproducibility reports**
+   `example/analyze_replicates.py` (invoked automatically by `run_pipeline.sh`) aggregates:
+   - peak-level overlap precision/recall, F1, bp-wise Jaccard, and sign concordance;
+   - top-N recovery of the most significant 2v2 peaks;
+   - Spearman correlations of log2 fold-changes between the 2v2 run and each 1v1 replicate pairing;
+   - a union log2FC matrix (`global_log2fc_matrix.tsv`) for downstream clustering/QC.
+
+All scripts respect relative paths, so you can copy the `example/` directory into your own project and customize it as needed.
+
+---
+
 ## 🔧 Command reference
 
 Run `python chipdiff.py --help` to see all available options (peak calling parameters, threading, annotation, and enrichment settings).

--- a/example/analyze_replicates.py
+++ b/example/analyze_replicates.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Assess reproducibility between 2v2 and 1v1 PeakForge runs."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+import pandas as pd
+import pyranges as pr
+from scipy import stats
+
+
+@dataclass
+class ResultBundle:
+    label: str
+    path: Path
+    full: pd.DataFrame
+    significant: pd.DataFrame
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Summarize replicate concordance for PeakForge outputs")
+    parser.add_argument("--main", required=True, help="Differential results from the 2v2 run")
+    parser.add_argument("--one-vs-one", nargs="+", required=True,
+                        help="Differential results from 1v1 runs (at least two files)")
+    parser.add_argument("--output-dir", required=True, help="Directory where reports will be written")
+    parser.add_argument("--alpha", type=float, default=0.05, help="Adjusted p-value cutoff")
+    parser.add_argument("--lfc", type=float, default=1.0, help="Absolute log2 fold-change cutoff")
+    parser.add_argument("--top-n", type=int, default=200,
+                        help="Top-N peaks (by padj) from the 2v2 run to evaluate overlap")
+    return parser.parse_args()
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def load_results(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"Results file not found: {path}")
+    df = pd.read_csv(path, sep="\t", index_col=0)
+    required = {"log2FC", "padj"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"Results file {path} missing required columns: {', '.join(sorted(missing))}")
+    df.index = df.index.astype(str)
+    return df
+
+
+def filter_significant(df: pd.DataFrame, alpha: float, lfc: float) -> pd.DataFrame:
+    mask = (df["padj"] <= alpha) & (df["log2FC"].abs() >= lfc)
+    return df.loc[mask].copy()
+
+
+def parse_peak(name: str) -> Tuple[str, int, int]:
+    chrom, coords = name.split(":", 1)
+    start_str, end_str = coords.split("-", 1)
+    return chrom, int(start_str.replace(",", "")), int(end_str.replace(",", ""))
+
+
+def peaks_to_ranges(df: pd.DataFrame) -> pr.PyRanges:
+    if df.empty:
+        return pr.PyRanges()
+    records = []
+    for peak in df.index:
+        try:
+            chrom, start, end = parse_peak(peak)
+        except Exception as exc:
+            raise ValueError(f"Failed to parse peak name '{peak}': {exc}") from exc
+        records.append({
+            "Chromosome": chrom,
+            "Start": int(start),
+            "End": int(end),
+            "Peak": peak,
+        })
+    return pr.PyRanges(pd.DataFrame.from_records(records))
+
+
+def overlap_pairs(main: pd.DataFrame, sub: pd.DataFrame) -> pd.DataFrame:
+    main_ranges = peaks_to_ranges(main)
+    sub_ranges = peaks_to_ranges(sub)
+    if len(main_ranges) == 0 or len(sub_ranges) == 0:
+        return pd.DataFrame(columns=["Peak_main", "Peak_sub"])
+    joined = main_ranges.join(sub_ranges, suffix="_sub")
+    if joined.df.empty:
+        return pd.DataFrame(columns=["Peak_main", "Peak_sub"])
+    cols = [col for col in joined.df.columns if col.startswith("Peak")]
+    mapping = joined.df[[cols[0], cols[1]]].drop_duplicates()
+    mapping.columns = ["Peak_main", "Peak_sub"]
+    return mapping
+
+
+def bp_length(ranges: pr.PyRanges) -> int:
+    if len(ranges) == 0:
+        return 0
+    merged = ranges.merge()
+    if merged.df.empty:
+        return 0
+    lengths = (merged.df["End"] - merged.df["Start"]).astype(int)
+    return int(lengths.sum())
+
+
+def evaluate_pair(main_bundle: ResultBundle, sub_bundle: ResultBundle, top_n: int) -> Dict[str, float]:
+    pairs = overlap_pairs(main_bundle.significant, sub_bundle.significant)
+    shared_main = set(pairs["Peak_main"]) if not pairs.empty else set()
+    shared_sub = set(pairs["Peak_sub"]) if not pairs.empty else set()
+
+    main_count = len(main_bundle.significant)
+    sub_count = len(sub_bundle.significant)
+    overlap_count = len(shared_main)
+    precision = overlap_count / sub_count if sub_count else 0.0
+    recall = overlap_count / main_count if main_count else 0.0
+
+    concordance = float("nan")
+    spearman_r = float("nan")
+    spearman_p = float("nan")
+    mean_abs_diff = float("nan")
+    if overlap_count:
+        merged = pairs.drop_duplicates()
+        merged["log2FC_main"] = main_bundle.significant.loc[merged["Peak_main"], "log2FC"].to_numpy()
+        merged["log2FC_sub"] = sub_bundle.significant.loc[merged["Peak_sub"], "log2FC"].to_numpy()
+        concordance = float((np.sign(merged["log2FC_main"]) == np.sign(merged["log2FC_sub"]).mean()))
+        if overlap_count > 1:
+            spearman_r, spearman_p = stats.spearmanr(merged["log2FC_main"], merged["log2FC_sub"])
+        mean_abs_diff = float(np.mean(np.abs(merged["log2FC_main"] - merged["log2FC_sub"])))
+
+    main_ranges = peaks_to_ranges(main_bundle.significant)
+    sub_ranges = peaks_to_ranges(sub_bundle.significant)
+    overlap_bp = bp_length(main_ranges.intersect(sub_ranges)) if len(main_ranges) and len(sub_ranges) else 0
+    union_ranges = pr.PyRanges(pd.concat([main_ranges.df, sub_ranges.df], ignore_index=True)) if overlap_bp else None
+    union_bp = bp_length(union_ranges) if union_ranges is not None else (
+        bp_length(main_ranges) + bp_length(sub_ranges)
+    )
+    jaccard = overlap_bp / union_bp if union_bp else 0.0
+
+    top_n = min(top_n, len(main_bundle.significant))
+    top_overlap_fraction = 0.0
+    if top_n:
+        top_main = main_bundle.significant.sort_values("padj").head(top_n)
+        top_pairs = overlap_pairs(top_main, sub_bundle.significant)
+        unique_top = set(top_pairs["Peak_main"]) if not top_pairs.empty else set()
+        top_overlap_fraction = len(unique_top) / top_n if top_n else 0.0
+
+    return {
+        "comparison": sub_bundle.label,
+        "n_significant_main": main_count,
+        "n_significant_1v1": sub_count,
+        "n_overlap": overlap_count,
+        "precision": precision,
+        "recall": recall,
+        "f1": (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0,
+        "sign_concordance": concordance,
+        "spearman_r": spearman_r,
+        "spearman_p": spearman_p,
+        "mean_abs_log2fc_diff": mean_abs_diff,
+        "overlap_bp": overlap_bp,
+        "union_bp": union_bp,
+        "jaccard_bp": jaccard,
+        "top_n": top_n,
+        "top_overlap_fraction": top_overlap_fraction,
+    }
+
+
+def load_bundle(label: str, path: Path, alpha: float, lfc: float) -> ResultBundle:
+    full = load_results(path)
+    significant = filter_significant(full, alpha, lfc)
+    return ResultBundle(label=label, path=path, full=full, significant=significant)
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = ensure_dir(Path(args.output_dir))
+
+    main_bundle = load_bundle("2v2", Path(args.main), args.alpha, args.lfc)
+    comparisons: List[ResultBundle] = []
+    for path in args.one_vs_one:
+        label = Path(path).parent.name
+        comparisons.append(load_bundle(label, Path(path), args.alpha, args.lfc))
+
+    summary_rows = [evaluate_pair(main_bundle, bundle, args.top_n) for bundle in comparisons]
+    summary_df = pd.DataFrame(summary_rows)
+    summary_path = output_dir / "replicate_overlap_summary.tsv"
+    summary_df.to_csv(summary_path, sep="\t", index=False)
+
+    review = {
+        "alpha": args.alpha,
+        "lfc": args.lfc,
+        "top_n": args.top_n,
+        "main_results": str(main_bundle.path),
+        "comparisons": [row for row in summary_rows],
+    }
+    (output_dir / "replicate_overlap_summary.json").write_text(json.dumps(review, indent=2))
+
+    global_matrix = build_global_matrix(main_bundle, comparisons)
+    global_matrix.to_csv(output_dir / "global_log2fc_matrix.tsv", sep="\t")
+
+
+def build_global_matrix(main_bundle: ResultBundle, comparisons: Iterable[ResultBundle]) -> pd.DataFrame:
+    frames = {main_bundle.label: main_bundle.full["log2FC"]}
+    for bundle in comparisons:
+        frames[bundle.label] = bundle.full["log2FC"]
+    combined = pd.concat(frames, axis=1)
+    combined.index.name = "Peak"
+    return combined
+
+
+if __name__ == "__main__":
+    main()

--- a/example/data/metadata.tsv
+++ b/example/data/metadata.tsv
@@ -1,0 +1,5 @@
+sample	condition	bam
+GM12878_rep1	GM12878	example/data/GM12878_rep1.bam
+GM12878_rep2	GM12878	example/data/GM12878_rep2.bam
+K562_rep1	K562	example/data/K562_rep1.bam
+K562_rep2	K562	example/data/K562_rep2.bam

--- a/example/download_encode.sh
+++ b/example/download_encode.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="${ROOT}/data"
+MANIFEST="${DATA_DIR}/encode_manifest.tsv"
+mkdir -p "${DATA_DIR}"
+
+: "${DRY_RUN:=1}"
+
+cat <<'BANNER'
+This helper fetches a matched 2 vs 2 ENCODE ChIP-seq dataset (hg38):
+  - GM12878 H3K27ac (ENCSR000AKP)
+  - K562 H3K27ac (ENCSR000AKO)
+
+By default the script runs in DRY-RUN mode and only prints the curl
+commands.  Set DRY_RUN=0 to download the files.
+BANNER
+
+python3 - <<'PY' "${DATA_DIR}" "${MANIFEST}" "${DRY_RUN}"
+import json
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+BASE = "https://www.encodeproject.org"
+HEADERS = {
+    "User-Agent": "PeakForge-fetcher/1.0 (+https://github.com/)",
+    "Accept": "application/json",
+}
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers=HEADERS)
+    # Respect proxies from the environment
+    opener = urllib.request.build_opener()
+    with opener.open(req) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Failed to fetch {url} (HTTP {resp.status})")
+        return json.load(resp)
+
+def iter_files(experiment: str) -> list[dict]:
+    params = {
+        "type": "File",
+        "dataset": experiment,
+        "output_type": "alignments",
+        "assembly": "GRCh38",
+        "file_format": "bam",
+        "status": "released",
+        "limit": "all",
+        "format": "json",
+        "field": [
+            "accession",
+            "href",
+            "md5sum",
+            "file_format",
+            "file_type",
+            "replicate.title",
+            "replicate.biological_replicate_number",
+            "replicate.technical_replicate_number",
+            "preferred_default",
+        ],
+    }
+    query = urllib.parse.urlencode(params, doseq=True)
+    url = f"{BASE}/search/?{query}"
+    data = fetch_json(url)
+    return data["@graph"]
+
+def select_replicates(records: list[dict], count: int = 2) -> list[dict]:
+    sorted_records = sorted(
+        records,
+        key=lambda rec: (
+            rec.get("replicate", {}).get("biological_replicate_number", 99),
+            rec.get("replicate", {}).get("technical_replicate_number", 99),
+            not rec.get("preferred_default", False),
+            rec.get("accession"),
+        ),
+    )
+    selected = []
+    seen = set()
+    for rec in sorted_records:
+        rep = rec.get("replicate") or {}
+        bio = rep.get("biological_replicate_number")
+        if bio is None or bio in seen:
+            continue
+        selected.append(rec)
+        seen.add(bio)
+        if len(selected) == count:
+            break
+    if len(selected) < count:
+        raise RuntimeError(f"Expected >= {count} replicates but found {len(selected)}")
+    return selected
+
+def main(data_dir: Path, manifest_path: Path, dry_run: bool) -> None:
+    experiments = [
+        ("GM12878", "ENCSR000AKP"),
+        ("K562", "ENCSR000AKO"),
+    ]
+    rows = ["sample\tcondition\taccession\tdestination\tmd5sum\turl"]
+    for condition, experiment in experiments:
+        files = select_replicates(iter_files(experiment))
+        for rec in files:
+            rep = rec.get("replicate") or {}
+            bio = rep.get("biological_replicate_number")
+            accession = rec["accession"]
+            ext = rec.get("file_format", "bam")
+            dest = data_dir / f"{condition}_rep{bio}.{ext}"
+            download_url = f"{BASE}/files/{accession}/@@download/{accession}.{ext}"
+            rows.append(
+                "\t".join(
+                    [
+                        f"{condition}_rep{bio}",
+                        condition,
+                        accession,
+                        str(dest),
+                        rec.get("md5sum", ""),
+                        download_url,
+                    ]
+                )
+            )
+            cmd = [
+                "curl",
+                "-L",
+                "-H",
+                "Accept: application/json",
+                "-o",
+                str(dest),
+                download_url,
+            ]
+            print("[command]", " ".join(cmd))
+            if not dry_run:
+                data_dir.mkdir(parents=True, exist_ok=True)
+                import subprocess
+
+                subprocess.run(cmd, check=True)
+    manifest_path.write_text("\n".join(rows) + "\n")
+    print(f"Manifest written to {manifest_path}")
+
+if __name__ == "__main__":
+    data_dir = Path(sys.argv[1])
+    manifest_path = Path(sys.argv[2])
+    dry_run = bool(int(sys.argv[3]))
+    main(data_dir, manifest_path, dry_run)
+PY
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  echo "(dry-run) No files were downloaded. Re-run with DRY_RUN=0 to fetch data."
+fi
+
+python3 - <<'PY' "${DATA_DIR}"
+from pathlib import Path
+metadata = Path("example/data/metadata.tsv")
+if metadata.exists():
+    print(f"Metadata sheet already present: {metadata}")
+else:
+    print("WARNING: metadata.tsv is missing; create it before running the pipeline.")
+PY

--- a/example/run_pipeline.sh
+++ b/example/run_pipeline.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${ROOT}/.." && pwd)"
+DATA_DIR="${ROOT}/data"
+METADATA="${DATA_DIR}/metadata.tsv"
+RESULTS_ROOT="${RESULTS_ROOT:-${ROOT}/results}"
+THREADS="${THREADS:-4}"
+
+if [[ ! -f "${METADATA}" ]]; then
+  echo "Metadata sheet not found: ${METADATA}" >&2
+  exit 1
+fi
+
+mkdir -p "${RESULTS_ROOT}"
+
+# Parse metadata.tsv to build sample -> bam and condition mappings.
+declare -A SAMPLE_BAMS
+declare -A CONDITION_SAMPLES
+declare -A CONDITION_SEEN
+declare -a CONDITION_ORDER
+
+while IFS=$'\t' read -r sample condition bam; do
+  if [[ -z "${sample}" || "${sample}" == sample ]]; then
+    continue
+  fi
+  SAMPLE_BAMS["${sample}"]="${bam}"
+  CONDITION_SAMPLES["${condition}"]+=" ${sample}"
+  if [[ -z "${CONDITION_SEEN[${condition}]:-}" ]]; then
+    CONDITION_ORDER+=("${condition}")
+    CONDITION_SEEN["${condition}"]=1
+  fi
+done < "${METADATA}"
+
+if [[ "${#CONDITION_ORDER[@]}" -ne 2 ]]; then
+  echo "Expected exactly 2 conditions but found ${#CONDITION_ORDER[@]}" >&2
+  exit 1
+fi
+
+COND_A="${CONDITION_ORDER[0]}"
+COND_B="${CONDITION_ORDER[1]}"
+read -ra REPS_A <<<"${CONDITION_SAMPLES[${COND_A}]}"
+read -ra REPS_B <<<"${CONDITION_SAMPLES[${COND_B}]}"
+
+if [[ "${#REPS_A[@]}" -lt 2 || "${#REPS_B[@]}" -lt 2 ]]; then
+  echo "Need at least two replicates per condition for 2v2 example" >&2
+  exit 1
+fi
+
+run_chipdiff() {
+  local metadata_path="$1"
+  local output_dir="$2"
+  shift 2
+  mkdir -p "${output_dir}"
+  echo "[chipdiff] ${metadata_path} -> ${output_dir}"
+  python "${PROJECT_ROOT}/chipdiff.py" \
+    --metadata "${metadata_path}" \
+    --output-dir "${output_dir}" \
+    --peak-dir "${output_dir}/peaks" \
+    --min-overlap 2 \
+    --macs2-genome hs \
+    --threads "${THREADS}" \
+    "$@"
+}
+
+MAIN_DIR="${RESULTS_ROOT}/2v2"
+run_chipdiff "${METADATA}" "${MAIN_DIR}"
+
+ONE_VS_ONE_RESULTS=()
+for sample_a in "${REPS_A[@]}"; do
+  for sample_b in "${REPS_B[@]}"; do
+    tmp_metadata="$(mktemp "${RESULTS_ROOT}/1v1_${sample_a}_vs_${sample_b}_XXXX.tsv")"
+    {
+      printf 'sample\tcondition\tbam\n'
+      printf '%s\t%s\t%s\n' "${sample_a}" "${COND_A}" "${SAMPLE_BAMS[${sample_a}]}"
+      printf '%s\t%s\t%s\n' "${sample_b}" "${COND_B}" "${SAMPLE_BAMS[${sample_b}]}"
+    } > "${tmp_metadata}"
+    out_dir="${RESULTS_ROOT}/1v1_${sample_a}_vs_${sample_b}"
+    run_chipdiff "${tmp_metadata}" "${out_dir}" --min-overlap 1
+    ONE_VS_ONE_RESULTS+=("${out_dir}/differential_results.tsv")
+    rm -f "${tmp_metadata}"
+  done
+done
+
+REPORT_DIR="${RESULTS_ROOT}/reports"
+python "${ROOT}/analyze_replicates.py" \
+  --main "${MAIN_DIR}/differential_results.tsv" \
+  --one-vs-one "${ONE_VS_ONE_RESULTS[@]}" \
+  --output-dir "${REPORT_DIR}" \
+  --alpha "${ALPHA:-0.05}" \
+  --lfc "${LFC_THRESHOLD:-1.0}"
+
+echo "All analyses completed. Review ${REPORT_DIR} for reproducibility summaries."


### PR DESCRIPTION
## Summary
- add an `example/` workflow that can download a public ENCODE hg38 H3K27ac 2v2 dataset and run PeakForge end-to-end
- provide a Python analysis helper to compare the 2v2 differential results against all 1v1 replicate contrasts with overlap, concordance, and correlation metrics
- document the new example workflow and reproducibility outputs in the README

## Testing
- bash -n example/download_encode.sh
- bash -n example/run_pipeline.sh
- python -m compileall example/analyze_replicates.py

------
https://chatgpt.com/codex/tasks/task_e_68df4dd957cc8327bf7d87f3340cea60