### PR TITLE
Update example to MYC K562 vs HepG2 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Key files generated under `results/` include:
 
 ## 🧬 ENCODE hg38 2v2 example dataset
 
-To help you get started quickly, the repository ships with an end-to-end example based on a widely used ENCODE H3K27ac dataset (hg38):
+To help you get started quickly, the repository ships with an end-to-end example based on a matched ENCODE MYC ChIP-seq dataset (hg38):
 
-- **GM12878 H3K27ac** – ENCSR000AKP
-- **K562 H3K27ac** – ENCSR000AKO
+- **K562 MYC** – replicates [`ENCFF975ETI.bam`, `ENCFF380OWL.bam`]
+- **HepG2 MYC** – replicates [`ENCFF315AUW.bam`, `ENCFF987GJQ.bam`]
 
 The scripts in `example/` orchestrate downloading the public alignments, executing the PeakForge pipeline for the 2 vs 2 comparison, repeating all four possible 1 vs 1 contrasts, and benchmarking how closely the 1 vs 1 runs reproduce the 2 vs 2 signal.
 

--- a/example/data/metadata.tsv
+++ b/example/data/metadata.tsv
@@ -1,5 +1,5 @@
 sample	condition	bam
-GM12878_rep1	GM12878	example/data/GM12878_rep1.bam
-GM12878_rep2	GM12878	example/data/GM12878_rep2.bam
 K562_rep1	K562	example/data/K562_rep1.bam
 K562_rep2	K562	example/data/K562_rep2.bam
+HepG2_rep1	HepG2	example/data/HepG2_rep1.bam
+HepG2_rep2	HepG2	example/data/HepG2_rep2.bam


### PR DESCRIPTION
## Summary
- refresh the README example description to point to the MYC K562 vs HepG2 comparison
- hard-code the ENCODE BAM download links for the new replicates in the helper script
- update the example metadata sheet to match the MYC dataset sample names

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df64d090848327b9d4359ef5c4ce3b