### PR TITLE
Fix DESeq design dtype and add direct-run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,27 @@ The scripts in `example/` orchestrate downloading the public alignments, executi
 
 All scripts respect relative paths, so you can copy the `example/` directory into your own project and customize it as needed.
 
+### Example 2: use existing BAM/peak files directly
+
+If you already have the BAMs (and optionally MACS2 peak calls) on disk, the
+helper script `example/run_example2.sh` lets you drive the full pipeline
+without re-running the download/index step:
+
+```bash
+bash example/run_example2.sh \
+  --condition-a K562 \
+  --a-bams example/data/K562_rep1.bam example/data/K562_rep2.bam \
+  --a-peaks example/results/2v2/peaks/K562_rep1_summits.bed example/results/2v2/peaks/K562_rep2_summits.bed \
+  --condition-b HepG2 \
+  --b-bams example/data/HepG2_rep1.bam example/data/HepG2_rep2.bam \
+  --b-peaks example/results/2v2/peaks/HepG2_rep1_summits.bed example/results/2v2/peaks/HepG2_rep2_summits.bed
+```
+
+The script generates a temporary metadata sheet that points to the supplied
+paths and then invokes `chipdiff.py` with sensible defaults. Provide peak files
+to skip MACS2 entirely; omit them if you want the pipeline to call peaks from
+your BAMs on the fly.
+
 ---
 
 ## 🔧 Command reference

--- a/chipdiff.py
+++ b/chipdiff.py
@@ -377,7 +377,7 @@ def estimate_dispersions(normalized: pd.DataFrame) -> Tuple[np.ndarray, np.ndarr
 def wald_test_deseq(counts: pd.DataFrame, conditions: pd.Series,
                      size_factors: np.ndarray, dispersions: np.ndarray) -> pd.DataFrame:
     samples = counts.columns.tolist()
-    design = pd.get_dummies(conditions.loc[samples], drop_first=True)
+    design = pd.get_dummies(conditions.loc[samples], drop_first=True, dtype=float)
     if design.shape[1] != 1:
         raise ValueError("DESeq2-like workflow currently supports exactly two conditions with replicates")
     cond_col = design.columns[0]

--- a/example/run_example2.sh
+++ b/example/run_example2.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'USAGE'
+Usage: run_example2.sh [options]
+
+Run the PeakForge pipeline using already-downloaded BAM files and optional
+pre-computed peak calls. This helper creates a temporary metadata sheet for
+you so you can launch the full pipeline without re-downloading or
+re-indexing inputs.
+
+Required arguments:
+  --condition-a NAME         Label for condition A (e.g. K562)
+  --a-bams FILE [FILE ...]   One or more BAMs belonging to condition A
+  --condition-b NAME         Label for condition B (e.g. HepG2)
+  --b-bams FILE [FILE ...]   One or more BAMs belonging to condition B
+
+Optional arguments:
+  --a-peaks FILE [FILE ...]  Peak files aligned with --a-bams (summits.bed,
+                             narrowPeak, or broadPeak). When provided, MACS2
+                             is skipped for those samples.
+  --b-peaks FILE [FILE ...]  Peak files aligned with --b-bams.
+  --output-dir DIR           Output directory (default: example/results/example2)
+  --threads N                Threads for multiBamSummary (default: 4)
+  --min-overlap N            Minimum samples required for consensus peaks (default: 2)
+  --peak-type TYPE           Default peak type when calling MACS2 (default: narrow)
+  --summit-extension BP      Summit extension/half-window size (default: 250)
+  --macs2-genome G           Genome size string passed to MACS2 (default: hs)
+  -h, --help                 Show this help message and exit
+
+Example:
+  bash run_example2.sh \
+    --condition-a K562 \
+    --a-bams data/K562_rep1.bam data/K562_rep2.bam \
+    --a-peaks results/2v2/peaks/K562_rep1_summits.bed results/2v2/peaks/K562_rep2_summits.bed \
+    --condition-b HepG2 \
+    --b-bams data/HepG2_rep1.bam data/HepG2_rep2.bam \
+    --b-peaks results/2v2/peaks/HepG2_rep1_summits.bed results/2v2/peaks/HepG2_rep2_summits.bed
+USAGE
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+COND_A=""
+COND_B=""
+OUTPUT_DIR="${SCRIPT_DIR}/results/example2"
+THREADS=4
+MIN_OVERLAP=2
+PEAK_TYPE="narrow"
+SUMMIT_EXTENSION=250
+MACS2_GENOME="hs"
+A_BAMS=()
+B_BAMS=()
+A_PEAKS=()
+B_PEAKS=()
+
+if [[ $# -eq 0 ]]; then
+  show_help
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --condition-a)
+      COND_A="$2"
+      shift 2
+      ;;
+    --condition-b)
+      COND_B="$2"
+      shift 2
+      ;;
+    --a-bams)
+      shift
+      while [[ $# -gt 0 && $1 != --* ]]; do
+        A_BAMS+=("$1")
+        shift
+      done
+      ;;
+    --b-bams)
+      shift
+      while [[ $# -gt 0 && $1 != --* ]]; do
+        B_BAMS+=("$1")
+        shift
+      done
+      ;;
+    --a-peaks)
+      shift
+      while [[ $# -gt 0 && $1 != --* ]]; do
+        A_PEAKS+=("$1")
+        shift
+      done
+      ;;
+    --b-peaks)
+      shift
+      while [[ $# -gt 0 && $1 != --* ]]; do
+        B_PEAKS+=("$1")
+        shift
+      done
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --threads)
+      THREADS="$2"
+      shift 2
+      ;;
+    --min-overlap)
+      MIN_OVERLAP="$2"
+      shift 2
+      ;;
+    --peak-type)
+      PEAK_TYPE="$2"
+      shift 2
+      ;;
+    --summit-extension)
+      SUMMIT_EXTENSION="$2"
+      shift 2
+      ;;
+    --macs2-genome)
+      MACS2_GENOME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      show_help >&2
+      exit 1
+      ;;
+    *)
+      echo "Unexpected argument: $1" >&2
+      show_help >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${COND_A}" || -z "${COND_B}" ]]; then
+  echo "Both --condition-a and --condition-b are required" >&2
+  exit 1
+fi
+
+if [[ ${#A_BAMS[@]} -eq 0 || ${#B_BAMS[@]} -eq 0 ]]; then
+  echo "You must supply at least one BAM for each condition" >&2
+  exit 1
+fi
+
+if [[ ${#A_PEAKS[@]} -gt 0 && ${#A_PEAKS[@]} -ne ${#A_BAMS[@]} ]]; then
+  echo "Number of --a-peaks entries must match --a-bams" >&2
+  exit 1
+fi
+
+if [[ ${#B_PEAKS[@]} -gt 0 && ${#B_PEAKS[@]} -ne ${#B_BAMS[@]} ]]; then
+  echo "Number of --b-peaks entries must match --b-bams" >&2
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}" "${OUTPUT_DIR}/peaks"
+metadata_path="$(mktemp)"
+trap 'rm -f "${metadata_path}"' EXIT
+
+{
+  printf 'sample\tcondition\tbam\tpeaks\tpeak_type\n'
+  for idx in "${!A_BAMS[@]}"; do
+    bam="${A_BAMS[$idx]}"
+    sample="${COND_A}_rep$((idx + 1))"
+    peak="-"
+    peak_type="-"
+    if [[ ${#A_PEAKS[@]} -gt 0 ]]; then
+      peak="${A_PEAKS[$idx]}"
+      peak_type="auto"
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\n' "${sample}" "${COND_A}" "${bam}" "${peak}" "${peak_type}"
+  done
+  for idx in "${!B_BAMS[@]}"; do
+    bam="${B_BAMS[$idx]}"
+    sample="${COND_B}_rep$((idx + 1))"
+    peak="-"
+    peak_type="-"
+    if [[ ${#B_PEAKS[@]} -gt 0 ]]; then
+      peak="${B_PEAKS[$idx]}"
+      peak_type="auto"
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\n' "${sample}" "${COND_B}" "${bam}" "${peak}" "${peak_type}"
+  done
+} > "${metadata_path}"
+
+echo "[example2] Metadata written to ${metadata_path}" >&2
+
+echo "[example2] Launching PeakForge..." >&2
+python "${PROJECT_ROOT}/chipdiff.py" \
+  --metadata "${metadata_path}" \
+  --output-dir "${OUTPUT_DIR}" \
+  --peak-dir "${OUTPUT_DIR}/peaks" \
+  --min-overlap "${MIN_OVERLAP}" \
+  --macs2-genome "${MACS2_GENOME}" \
+  --peak-type "${PEAK_TYPE}" \
+  --summit-extension "${SUMMIT_EXTENSION}" \
+  --threads "${THREADS}"
+
+echo "[example2] Results available in ${OUTPUT_DIR}" >&2


### PR DESCRIPTION
## Summary
- ensure the DESeq-style design matrix uses a float dtype so statsmodels no longer trips over boolean subtraction when replicates are present
- add `example/run_example2.sh` plus README instructions to run the pipeline directly from existing BAM/peak files without rerunning downloads

## Testing
- `python - <<'PY'
import pandas as pd
import numpy as np
import chipdiff
counts = pd.DataFrame(np.random.poisson(100, size=(50,4)), columns=['A1','A2','B1','B2'])
conditions = pd.Series({'A1':'A','A2':'A','B1':'B','B2':'B'})
res = chipdiff.call_differential_analysis(counts, conditions)
print(res.head())
PY`
- `example/run_example2.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68df827e6ce883279f078374c57a326b