### PR TITLE
Remove internal DESeq-like workflow and rely on PyDESeq2

### DIFF
--- a/example/data/metadata_1v1.tsv
+++ b/example/data/metadata_1v1.tsv
@@ -1,0 +1,3 @@
+sample	condition	bam
+K562_rep1	K562	example/data/K562_rep1.bam
+HepG2_rep1	HepG2	example/data/HepG2_rep1.bam

--- a/example/run_example_1v1.sh
+++ b/example/run_example_1v1.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${ROOT}/.." && pwd)"
+METADATA="${ROOT}/data/metadata_1v1.tsv"
+RESULTS_DIR="${RESULTS_DIR:-${ROOT}/results_1v1}"
+THREADS="${THREADS:-4}"
+
+if [[ ! -f "${METADATA}" ]]; then
+  echo "Metadata sheet not found: ${METADATA}" >&2
+  exit 1
+fi
+
+mkdir -p "${RESULTS_DIR}" "${RESULTS_DIR}/peaks"
+
+echo "[chipdiff] Running 1v1 example -> ${RESULTS_DIR}" \
+  && python "${PROJECT_ROOT}/chipdiff.py" \
+    --metadata "${METADATA}" \
+    --output-dir "${RESULTS_DIR}" \
+    --peak-dir "${RESULTS_DIR}/peaks" \
+    --min-overlap 1 \
+    --macs2-genome hs \
+    --threads "${THREADS}"
+
+echo "Results written to ${RESULTS_DIR}" \
+  && echo "Inspect ${RESULTS_DIR}/differential_results.tsv for MARS outputs."


### PR DESCRIPTION
## Summary
- drop the in-repo DESeq2-like normalization/dispersion code path and require PyDESeq2 when replicates are present
- update documentation to reflect PyDESeq2-only replicate workflow and clarify the no-replicate example uses MARS
- adjust the 1v1 helper messaging to point at MARS-generated results

## Testing
- python -m compileall chipdiff.py

------
https://chatgpt.com/codex/tasks/task_e_68df8ceb97408327b54289253bf803ad