### PR TITLE
Use BAM library sizes for MARS and simplify CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It takes BAM or MACS2 peak files as input, builds consensus peaks, counts reads,
     - Requires PyDESeq2 to be installed when replicate designs are detected.
   - **MARS (DEGseq, Likun Wang 2010)** (without replicates):
     - Supports 1 vs 1, or pooled multiple vs multiple samples.
-    - MA-plot based exact binomial test.
+    - Uses `samtools idxstats` to derive per-sample library sizes from the full BAM before applying the MA-plot random sampling test.
   - Consolidated differential results (`differential_results.tsv`) for downstream interpretation.
 
 - **Annotation & Enrichment (optional)**
@@ -53,7 +53,7 @@ Requirements:
 - External tools:
   - [MACS2](https://github.com/macs3-project/MACS) (for peak calling)
   - [deepTools](https://deeptools.readthedocs.io/en/develop/) (for multiBamSummary)
-  - [samtools](http://www.htslib.org/) (for BAM indexing)
+  - [samtools](http://www.htslib.org/) (for BAM indexing and library size estimation)
 
 Install dependencies:
 
@@ -67,7 +67,7 @@ conda install -c bioconda macs2 deeptools samtools
 ## 🧪 Quick start
 
 1. Prepare a sample sheet (`samples.tsv`) describing your BAM files and optional peak calls.
-2. Run the pipeline with `python chipdiff.py --metadata samples.tsv --output-dir results`.
+2. Run the pipeline with `./peakforge tsvmode samples.tsv --output-dir results` (or `python chipdiff.py tsvmode samples.tsv --output-dir results`).
 3. Inspect the figures and result tables written to the `results/` directory.
 
 ### Sample sheet format
@@ -83,8 +83,7 @@ The sheet can be tab- or comma-delimited and must include the columns `sample`, 
 ### Example command
 
 ```bash
-python chipdiff.py \
-  --metadata samples.tsv \
+./peakforge tsvmode samples.tsv \
   --output-dir results \
   --peak-dir peaks \
   --min-overlap 2 \
@@ -169,11 +168,10 @@ bash example/run_example2.sh \
   --b-peaks example/results/2v2/peaks/HepG2_rep1_summits.bed
 ```
 
-The script generates a temporary metadata sheet that points to the supplied
-paths and then invokes `chipdiff.py` with sensible defaults (including
-`--threads 16`, which maps to `multiBamSummary --numberOfProcessors`). Provide
-peak files to skip MACS2 entirely; omit them if you want the pipeline to call
-peaks from your BAMs on the fly.
+The script calls `peakforge runmode` with the provided paths and sensible
+defaults (including `--threads 16`, which maps to `multiBamSummary
+--numberOfProcessors`). Provide peak files to skip MACS2 entirely; omit them if
+you want the pipeline to call peaks from your BAMs on the fly.
 
 ### Example 3: 2v2 quick start
 
@@ -213,4 +211,4 @@ analysis.
 
 ## 🔧 Command reference
 
-Run `python chipdiff.py --help` to see all available options (peak calling parameters, threading, annotation, and enrichment settings).
+Run `./peakforge --help` (or `python chipdiff.py --help`) to see all available options (peak calling parameters, threading, annotation, and enrichment settings).

--- a/example/run_example2.sh
+++ b/example/run_example2.sh
@@ -171,46 +171,31 @@ if [[ ${#B_PEAKS[@]} -gt 0 && ${#B_PEAKS[@]} -ne ${#B_BAMS[@]} ]]; then
 fi
 
 mkdir -p "${OUTPUT_DIR}" "${OUTPUT_DIR}/peaks"
-metadata_path="$(mktemp)"
-trap 'rm -f "${metadata_path}"' EXIT
 
-{
-  printf 'sample\tcondition\tbam\tpeaks\tpeak_type\n'
-  for idx in "${!A_BAMS[@]}"; do
-    bam="${A_BAMS[$idx]}"
-    sample="${COND_A}_rep$((idx + 1))"
-    peak="-"
-    peak_type="-"
-    if [[ ${#A_PEAKS[@]} -gt 0 ]]; then
-      peak="${A_PEAKS[$idx]}"
-      peak_type="auto"
-    fi
-    printf '%s\t%s\t%s\t%s\t%s\n' "${sample}" "${COND_A}" "${bam}" "${peak}" "${peak_type}"
-  done
-  for idx in "${!B_BAMS[@]}"; do
-    bam="${B_BAMS[$idx]}"
-    sample="${COND_B}_rep$((idx + 1))"
-    peak="-"
-    peak_type="-"
-    if [[ ${#B_PEAKS[@]} -gt 0 ]]; then
-      peak="${B_PEAKS[$idx]}"
-      peak_type="auto"
-    fi
-    printf '%s\t%s\t%s\t%s\t%s\n' "${sample}" "${COND_B}" "${bam}" "${peak}" "${peak_type}"
-  done
-} > "${metadata_path}"
+CMD=(
+  python "${PROJECT_ROOT}/chipdiff.py" runmode
+  --condition-a "${COND_A}"
+  --a-bams "${A_BAMS[@]}"
+  --condition-b "${COND_B}"
+  --b-bams "${B_BAMS[@]}"
+  --output-dir "${OUTPUT_DIR}"
+  --peak-dir "${OUTPUT_DIR}/peaks"
+  --min-overlap "${MIN_OVERLAP}"
+  --peak-type "${PEAK_TYPE}"
+  --summit-extension "${SUMMIT_EXTENSION}"
+  --macs2-genome "${MACS2_GENOME}"
+  --threads "${THREADS}"
+)
 
-echo "[example2] Metadata written to ${metadata_path}" >&2
+if [[ ${#A_PEAKS[@]} -gt 0 ]]; then
+  CMD+=(--a-peaks "${A_PEAKS[@]}")
+fi
+
+if [[ ${#B_PEAKS[@]} -gt 0 ]]; then
+  CMD+=(--b-peaks "${B_PEAKS[@]}")
+fi
 
 echo "[example2] Launching PeakForge..." >&2
-python "${PROJECT_ROOT}/chipdiff.py" \
-  --metadata "${metadata_path}" \
-  --output-dir "${OUTPUT_DIR}" \
-  --peak-dir "${OUTPUT_DIR}/peaks" \
-  --min-overlap "${MIN_OVERLAP}" \
-  --macs2-genome "${MACS2_GENOME}" \
-  --peak-type "${PEAK_TYPE}" \
-  --summit-extension "${SUMMIT_EXTENSION}" \
-  --threads "${THREADS}"
+"${CMD[@]}"
 
 echo "[example2] Results available in ${OUTPUT_DIR}" >&2

--- a/example/run_example_1v1.sh
+++ b/example/run_example_1v1.sh
@@ -14,9 +14,9 @@ fi
 
 mkdir -p "${RESULTS_DIR}" "${RESULTS_DIR}/peaks"
 
-echo "[chipdiff] Running 1v1 example -> ${RESULTS_DIR}" \
+echo "[peakforge] Running 1v1 example -> ${RESULTS_DIR}" \
   && python "${PROJECT_ROOT}/chipdiff.py" \
-    --metadata "${METADATA}" \
+    tsvmode "${METADATA}" \
     --output-dir "${RESULTS_DIR}" \
     --peak-dir "${RESULTS_DIR}/peaks" \
     --min-overlap 1 \

--- a/example/run_pipeline.sh
+++ b/example/run_pipeline.sh
@@ -53,9 +53,9 @@ run_chipdiff() {
   local output_dir="$2"
   shift 2
   mkdir -p "${output_dir}"
-  echo "[chipdiff] ${metadata_path} -> ${output_dir}"
+  echo "[peakforge] ${metadata_path} -> ${output_dir}"
   python "${PROJECT_ROOT}/chipdiff.py" \
-    --metadata "${metadata_path}" \
+    tsvmode "${metadata_path}" \
     --output-dir "${output_dir}" \
     --peak-dir "${output_dir}/peaks" \
     --min-overlap 2 \

--- a/peakforge
+++ b/peakforge
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Convenience wrapper for the PeakForge CLI."""
+from chipdiff import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- derive per-sample library sizes from BAM files with `samtools idxstats` so the MARS model uses full library totals and persist them in run metadata
- require samtools in the pipeline, feed the library sizes into the MARS test, and let the CLI auto-select the differential method without a manual type flag
- refresh the README and helper scripts to reflect automatic workflow selection and the updated dependencies

## Testing
- python -m py_compile chipdiff.py

------
https://chatgpt.com/codex/tasks/task_e_68df99aa52088327b87cf783cd2afa1d