### PR TITLE
Update README to highlight DiffBind-style capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # PeakForge
 
-**PeakForge** is a publishable-level Python pipeline for end-to-end CUT&Tag / ChIP-seq differential analysis.
-It takes BAM or MACS2 peak files as input, builds consensus peaks, counts reads, runs differential analysis (PyDESeq2 or MARS), and produces publication-quality figures.
+**PeakForge** is a Python-native, DiffBind-style toolkit for end-to-end CUT&Tag / ChIP-seq differential analysis.
+It takes BAM or MACS2 peak files as input, builds consensus peaks, counts reads, and runs differential analysis (PyDESeq2 or MARS) whether or not biological replicates are available.
+Beyond standard replicate-aware testing, the pipeline supports single-sample vs single-sample contrasts for cases where cohesive motif/regulon signals make no-replicate comparisons informative.
 
 ---
 
@@ -69,7 +70,7 @@ conda install -c bioconda macs2 deeptools samtools
 
 1. Prepare a sample sheet (`samples.tsv`) describing your BAM files and optional peak calls.
 2. Run the pipeline with `./peakforge tsvmode samples.tsv --output-dir results` (or `python chipdiff.py tsvmode samples.tsv --output-dir results`).
-3. Inspect the figures and result tables written to the `results/` directory.
+3. Inspect the summary plots and result tables written to the `results/` directory.
 
 ### Sample sheet format
 
@@ -92,7 +93,7 @@ The sheet can be tab- or comma-delimited and must include the columns `sample`, 
   --enrichr
 ```
 
-This run will call peaks (if needed), build consensus peaks across samples, compute counts, perform PyDESeq2-based differential analysis when replicates are present (falling back to MARS otherwise), optionally annotate peaks, and produce publication-ready plots.
+This run will call peaks (if needed), build consensus peaks across samples, compute counts, perform PyDESeq2-based differential analysis when replicates are present (falling back to MARS otherwise), optionally annotate peaks, and generate standard comparison plots.
 
 `multiBamSummary` is invoked with `--numberOfProcessors 16` by default; override with `--threads` if you need a different level of parallelism.
 
@@ -213,6 +214,10 @@ output directory. Pass that file to either `tsvmode` or `runmode` with
 contrasts (for example, when you want to compare a single replicate against the
 2 vs 2 consensus). Doing so avoids re-running MACS2 and keeps fold-change
 estimates directly comparable across analyses.
+
+## 📝 TODO
+
+- Add a gallery of publication-level figures that showcases typical PeakForge outputs.
 
 ---
 


### PR DESCRIPTION
## Summary
- reframe the README introduction to emphasize PeakForge as a Python DiffBind-style toolkit that supports both replicate and no-replicate analyses
- soften figure-related language and note the plan to add publication-level visuals in a new TODO section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb0a36d2c8327827a240faba91f2d