### PR TITLE
Add peak shape subcommand to PeakForge CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Beyond standard replicate-aware testing, the pipeline supports single-sample vs 
   - Sample correlation heatmap.
   - Heatmap of top differential peaks.
   - Results tables (`.tsv`) and metadata (`.json`).
-  - Standalone peak shape profiling via `peak_shape.py` for comparing two bigWig
-    tracks over a BED of regions (with delta metrics and plots).
+  - Peak shape profiling via the integrated `peakforge peakshape` subcommand or
+    the standalone `peak_shape.py` module for comparing two bigWig tracks over a
+    BED of regions (with delta metrics and plots).
 
 ---
 
@@ -118,7 +119,7 @@ The repository also ships a standalone shape-profiling utility for comparing
 two signal tracks over a shared set of genomic regions:
 
 ```bash
-python peak_shape.py \
+./peakforge peakshape \
   --bigwig-a sampleA.bw \
   --bigwig-b sampleB.bw \
   --bed peaks.bed \
@@ -126,6 +127,9 @@ python peak_shape.py \
   --flank 1000 3000 \
   --out results/shape
 ```
+
+The same interface is available by calling `python peak_shape.py` directly if
+you prefer using the module as a standalone script.
 
 For each interval the script normalises the signal, computes FWHM, core:flank
 ratios, centroid shifts, and skewness, then records the per-sample values plus

--- a/chipdiff.py
+++ b/chipdiff.py
@@ -75,6 +75,8 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
     gseapy = None
 
+import peak_shape
+
 
 # ---------------------------------------------------------------------------
 # Data classes and utility helpers
@@ -1222,6 +1224,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_common_arguments(run_parser)
 
+    peakshape_parser = subparsers.add_parser(
+        "peakshape",
+        help="Run peak shape profiling for two bigWig tracks",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    peak_shape.add_cli_arguments(peakshape_parser)
+
     return parser
 
 
@@ -1246,6 +1255,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         elif args.command == "runmode":
             samples = build_runmode_samples(args)
             run_pipeline(args, samples=samples, metadata_path=None)
+        elif args.command == "peakshape":
+            peak_shape.run_peak_shape(args)
         else:  # pragma: no cover - defensive guard
             parser.print_help()
             sys.exit(1)


### PR DESCRIPTION
## Summary
- expose peak shape profiling through a new `peakforge peakshape` command
- refactor the `peak_shape` module for reusable argument wiring and logging control
- refresh the README to document the integrated workflow

## Testing
- python -m compileall chipdiff.py peak_shape.py

------
https://chatgpt.com/codex/tasks/task_e_68e0b82e97fc8327bac402e29a5868cd