### PR TITLE
Add BAM input support to peakshape and document coverage requirements

### DIFF
--- a/example/peak_shape/README.md
+++ b/example/peak_shape/README.md
@@ -42,4 +42,8 @@ generated files land in `data/` under this directory.
 Replace `data/demo_sample_*.bw` and `data/demo_regions.bed` with your own tracks
 and regions to visualise real datasets.  The helper script simply ensures the
 input files exist; if you supply your own data, skip the generation step and run
-`run_peak_shape.sh` directly.
+`run_peak_shape.sh` directly.  Real analyses work best with coverage bigWigs
+generated via `bamCoverage --outFileFormat bigwig` (use the same bin size and
+normalisation for both samples).  If you only have BAMs available, call the
+module with `--bam-a`/`--bam-b` to let PeakForge produce temporary bigWigs for
+you.


### PR DESCRIPTION
## Summary
- allow the peakshape subcommand to accept BAM inputs by auto-running bamCoverage with configurable parameters
- document the expected coverage-style bigWig inputs and the BAM conversion workflow in the main README
- update the peak shape example README with guidance on generating bigWigs and using the new BAM flags

## Testing
- python -m compileall peak_shape.py

------
https://chatgpt.com/codex/tasks/task_e_68e1c9748ee08327b0c01e4ea28db687