### PR TITLE
Fix replicate concordance calculation and expand documentation

### DIFF
--- a/example/analyze_replicates.py
+++ b/example/analyze_replicates.py
@@ -124,7 +124,7 @@ def evaluate_pair(main_bundle: ResultBundle, sub_bundle: ResultBundle, top_n: in
         merged = pairs.drop_duplicates()
         merged["log2FC_main"] = main_bundle.significant.loc[merged["Peak_main"], "log2FC"].to_numpy()
         merged["log2FC_sub"] = sub_bundle.significant.loc[merged["Peak_sub"], "log2FC"].to_numpy()
-        concordance = float((np.sign(merged["log2FC_main"]) == np.sign(merged["log2FC_sub"]).mean()))
+        concordance = float((np.sign(merged["log2FC_main"]) == np.sign(merged["log2FC_sub"])).mean())
         if overlap_count > 1:
             spearman_r, spearman_p = stats.spearmanr(merged["log2FC_main"], merged["log2FC_sub"])
         mean_abs_diff = float(np.mean(np.abs(merged["log2FC_main"] - merged["log2FC_sub"])))


### PR DESCRIPTION
## Summary
- correct the concordance metric in `example/analyze_replicates.py` so it averages the sign agreement rather than comparing against a scalar
- streamline and expand the README with a pipeline overview, installation verification, and troubleshooting guidance

## Testing
- python -m compileall example/analyze_replicates.py

------
https://chatgpt.com/codex/tasks/task_e_68e615aa3750832786075697e5ca2318