### PR TITLE
Remove inline citation markers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Many users asked how to *produce* and *ship* priors rather than only consume the
    trust.  This file becomes the `--prior-bed` input.
 2. **Summarise intensity with bigWigs** – Generate signal tracks that reflect the typical coverage over those regions.  A common
    pattern is `bamCoverage --normalizeUsing RPGC ... --outFileName reference.bw` followed by `multiBigwigSummary BED-file --bwfiles reference.bw --outRawCounts reference_prior.tsv --outFileName /tmp/ignore.npz`.  The resulting bigWig is supplied through
-   `--prior-bigwig` so PeakForge can compute expected read densities per prior interval.【F:prior_utils.py†L139-L149】
+   `--prior-bigwig` so PeakForge can compute expected read densities per prior interval.
 3. **Capture shape statistics** – Run `peakforge peakshape` (or `python peak_shape.py`) on the same training samples to export
    per-peak metrics.  The command `peakforge peakshape --peaks curated.bed --bam reference.bam --prior-shape stats.tsv` will emit
    a TSV that records distributions for width, summit sharpness, shoulder ratios, etc.  These statistics inform z-score scaling
@@ -57,7 +57,7 @@ Many users asked how to *produce* and *ship* priors rather than only consume the
    Shipping this folder with your project makes it trivial for collaborators to reproduce the same prior-aware analysis via
    `--prior-manifest`.
 
-The `example/run_with_prior.sh` script bootstraps a miniature manifest that demonstrates the whole workflow end to end.【F:example/run_with_prior.sh†L6-L66】
+The `example/run_with_prior.sh` script bootstraps a miniature manifest that demonstrates the whole workflow end to end.
 
 #### Supported prior artefacts
 - **BED intervals** (`--prior-bed` or manifest `prior_bed`): define a catalogue of curated peaks.  The loader normalises the
@@ -81,25 +81,25 @@ The `example/run_with_prior.sh` script bootstraps a miniature manifest that demo
    prioritising differential hits or plotting ranked lists.
 
 #### Why priors matter for 1 vs 1 contrasts
-Single replicate contrasts (1 treatment vs 1 control) lean on the MARS (MA-plot-based Random Sampling) test, which has limited power to distinguish noise from signal without additional information.【F:chipdiff.py†L1086-L1146】  Priors counteract this by providing reference behaviour for well-characterised loci:
+Single replicate contrasts (1 treatment vs 1 control) lean on the MARS (MA-plot-based Random Sampling) test, which has limited power to distinguish noise from signal without additional information.  Priors counteract this by providing reference behaviour for well-characterised loci:
 
 - **Overlap-driven shrinkage** – When an observed peak intersects the prior catalogue, its log fold-change is retained.  Novel
   peaks have their `log2FC` (and, when available, `log2FC_shrunk`) multiplied by `1 - w · (1 - overlap_fraction)`, where `w` is
-  `--prior-weight`.  This tempers aggressive fold-changes from noisy loci while preserving validated regions.【F:chipdiff.py†L1125-L1145】
+  `--prior-weight`.  This tempers aggressive fold-changes from noisy loci while preserving validated regions.
 - **Penalty-aware p-values** – Novel peaks also inherit a `penalty_factor = 1 + w · (1 - overlap_fraction)` that inflates
   p-values and standard errors.  When the prior weight is non-zero this makes the MARS output less overconfident in unexplored
-  regions, which is especially helpful with only two libraries.【F:chipdiff.py†L1125-L1146】
+  regions, which is especially helpful with only two libraries.
 - **Shape sanity checks** – Feeding shape priors into `peakforge peakshape` highlights peaks with atypical summit profiles
-  (`PriorShapeCategory`), flagging candidates that may deserve manual inspection before being called differential hits.【F:peak_shape.py†L513-L635】
+  (`PriorShapeCategory`), flagging candidates that may deserve manual inspection before being called differential hits.
 
 When tuning for 1v1 work:
 
 1. Start with a moderate `--prior-weight` such as `0.3–0.5`.  Inspect `differential_results_prior.tsv` to ensure familiar loci
-   remain high-confidence while novel peaks are merely down-weighted rather than discarded.【F:chipdiff.py†L1132-L1148】
+   remain high-confidence while novel peaks are merely down-weighted rather than discarded.
 2. Review the overlap tables (`peaks_prior_overlap.tsv`, `peaks_prior_novel.tsv`) to gauge how much of your catalogue is
-   supported by the data.【F:prior_utils.py†L398-L404】
+   supported by the data.
 3. Use the generated `prior_vs_observed.png` plot to confirm that observed signal distributions roughly align with the priors;
-   large discrepancies indicate that the weight should be reduced or the catalogue refreshed.【F:prior_utils.py†L444-L495】
+   large discrepancies indicate that the weight should be reduced or the catalogue refreshed.
 
 Following these steps gives the sparse 1 vs 1 branch enough context to stabilise fold-change estimates without hiding truly novel
 biology.


### PR DESCRIPTION
## Summary
- remove internal `【F:...】` citation markers from the README to keep the published documentation tidy

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d8ce8fb488327b9d0f453272e7597)