### PR TITLE
Clarify peak type handling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ The sheet can be tab- or comma-delimited and must include `sample`, `condition`,
   --enrichr
 ```
 This run performs peak calling (if necessary), constructs consensus intervals, quantifies counts, executes the appropriate differential workflow, annotates peaks, and produces summary plots.
+`--peak-type` controls whether MACS2 is invoked in narrow- or broad-peak mode when peaks are missing; narrow peaks are expanded symmetrically by `--peak-extension` (default 250 bp) to build the consensus, while broad peaks use their full width without extra padding.
+If you supply `narrowPeak` or `broadPeak` files in the sample sheet, PeakForge infers the mode from the extension and you can omit `--peak-type` entirely.
 
 ---
 


### PR DESCRIPTION
## Summary
- explain how `--peak-type` affects MACS2 mode and consensus building
- note that narrow peaks are extended while broad peaks keep their full widths
- mention that provided peak files allow omitting the flag

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed91ef78c8327836bee56cf4929fe)