### PR TITLE
feat(cli): add `makesheet` subcommand for easier metadata creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ environment.
 2. Run the pipeline: `./peakforge tsvmode samples.tsv --output-dir results` (or `python chipdiff.py tsvmode ...`).
 3. Review tables, plots, and metadata under `results/`.
 
+### Easier metadata generation (new)
+
+If hand-writing CSV/TSV feels tedious, you can now generate it directly from run arguments:
+
+```bash
+./peakforge makesheet \
+  --condition-a K562 \
+  --a-bams example/data/K562_rep1.bam example/data/K562_rep2.bam \
+  --a-peaks example/results/broad/K562_rep1_peaks.broadPeak example/results/broad/K562_rep2_peaks.broadPeak \
+  --condition-b HepG2 \
+  --b-bams example/data/HepG2_rep1.bam example/data/HepG2_rep2.bam \
+  --b-peaks example/results/broad/HepG2_rep1_peaks.broadPeak example/results/broad/HepG2_rep2_peaks.broadPeak \
+  --output samples.tsv
+```
+
+Then run as usual:
+
+```bash
+./peakforge tsvmode samples.tsv --output-dir results
+```
+
+`makesheet` supports both `.tsv` and `.csv` output paths and auto-generates unique sample IDs from BAM filenames.
+
 ### Sample sheet format
 
 The sheet can be tab- or comma-delimited and must include `sample`, `condition`, and `bam`. Optional columns let you
@@ -217,7 +240,7 @@ fold-change estimates directly comparable.
 
 ## Command reference
 Run `./peakforge --help` (or `python chipdiff.py --help`) to inspect CLI options including peak-calling parameters,
-threading controls, annotation, enrichment, and prior configuration.
+threading controls, annotation, enrichment, priors, and metadata-sheet helpers (`makesheet`).
 
 ---
 

--- a/chipdiff.py
+++ b/chipdiff.py
@@ -1531,6 +1531,26 @@ def build_runmode_samples(args: argparse.Namespace) -> List[SampleEntry]:
     return samples
 
 
+def write_sample_sheet(samples: Sequence[SampleEntry], output_path: Path) -> Path:
+    """Export sample metadata as TSV/CSV based on output extension."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    sep = "\t" if output_path.suffix.lower() != ".csv" else ","
+    frame = pd.DataFrame(
+        [
+            {
+                "sample": sample.sample,
+                "condition": sample.condition,
+                "bam": str(sample.bam),
+                "peaks": str(sample.peaks) if sample.peaks else "",
+                "peak_type": sample.peak_type,
+            }
+            for sample in samples
+        ]
+    )
+    frame.to_csv(output_path, sep=sep, index=False)
+    return output_path
+
+
 def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--output-dir", default="results", help="Output directory")
     parser.add_argument("--peak-dir", default="peaks", help="Directory for peak calls")
@@ -1631,6 +1651,34 @@ def build_parser() -> argparse.ArgumentParser:
     )
     peak_shape.add_cli_arguments(peakshape_parser)
 
+    sheet_parser = subparsers.add_parser(
+        "makesheet",
+        help="Generate a metadata TSV/CSV from runmode-style arguments",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    sheet_parser.add_argument("--condition-a", required=True, help="First condition label")
+    sheet_parser.add_argument("--a-bams", nargs="+", required=True, help="BAM files for condition A")
+    sheet_parser.add_argument(
+        "--a-peaks",
+        nargs="*",
+        default=None,
+        help="Optional peak files aligned with --a-bams",
+    )
+    sheet_parser.add_argument("--condition-b", required=True, help="Second condition label")
+    sheet_parser.add_argument("--b-bams", nargs="+", required=True, help="BAM files for condition B")
+    sheet_parser.add_argument(
+        "--b-peaks",
+        nargs="*",
+        default=None,
+        help="Optional peak files aligned with --b-bams",
+    )
+    sheet_parser.add_argument(
+        "--output",
+        required=True,
+        help="Output metadata file path (.tsv recommended, .csv supported)",
+    )
+    sheet_parser.add_argument("--log-level", default="INFO", help="Logging level")
+
     return parser
 
 
@@ -1656,6 +1704,10 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         elif args.command == "runmode":
             samples = build_runmode_samples(args)
             run_pipeline(args, samples=samples, metadata_path=None)
+        elif args.command == "makesheet":
+            samples = build_runmode_samples(args)
+            output_path = write_sample_sheet(samples, Path(args.output))
+            logging.info("Metadata sheet written to %s", output_path)
         elif args.command == "peakshape":
             peak_shape.run_peak_shape(args)
         else:  # pragma: no cover - defensive guard


### PR DESCRIPTION
### Motivation

- Preparing CSV/TSV sample sheets by hand was tedious and error-prone, so an automated helper was needed to generate consistent metadata from existing run-style arguments.
- The helper should reuse existing sample-name generation/validation so output is compatible with the existing `runmode` behavior.

### Description

- Added a new CLI subcommand `makesheet` that accepts `runmode`-style arguments (`--condition-a/--a-bams/--a-peaks/--condition-b/--b-bams/--b-peaks`) and an `--output` path to generate a metadata sheet.
- Implemented `write_sample_sheet(samples, output_path)` which auto-creates the output directory, selects TSV or CSV delimiter based on the output extension, and writes `sample`, `condition`, `bam`, `peaks`, and `peak_type` columns.
- Hooked `makesheet` into the main parser and entrypoint so `build_runmode_samples(...)` is reused to construct `SampleEntry` objects and ensure consistent sample IDs.
- Updated `README.md` Quick Start with a concrete `makesheet` example and added `makesheet` to the Command reference; also added a `--log-level` option to the `makesheet` parser to align logging with other subcommands.

### Testing

- Ran static bytecode checks with `python -m py_compile chipdiff.py io_utils.py prior_utils.py peak_shape.py`, which succeeded.
- Verified CLI help and subcommands via `python chipdiff.py --help` and `python chipdiff.py --help | head -n 60`, which showed the new `makesheet` entry.
- Performed a functional smoke test by running `python chipdiff.py makesheet --condition-a treated --a-bams data/A_rep1.bam data/A_rep2.bam --a-peaks peaks/A_rep1.narrowPeak peaks/A_rep2.narrowPeak --condition-b control --b-bams data/B_rep1.bam --output /tmp/peakforge_samples.tsv` and inspected `/tmp/peakforge_samples.tsv`, which was written as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab950cd5588327807f90981d694c7c)