### PR TITLE
Add per-peak prior intensity (PriorIntensity) and IntZ computation and integration

### DIFF
--- a/chipdiff.py
+++ b/chipdiff.py
@@ -1418,6 +1418,28 @@ def run_pipeline(
                     prior_covariates.loc[missing_mask, available] = peak_id_table.reindex(
                         counts_df.index[missing_mask]
                     )[available].to_numpy()
+
+        consensus_intensity = prior_registry.compute_consensus_intensity_z(consensus.df)
+        if not consensus_intensity.empty:
+            intensity_cols = ["PriorIntensity", "IntZ"]
+            intensity_name_table = consensus_intensity[["Name", *intensity_cols]].copy()
+            intensity_name_table = intensity_name_table.dropna(subset=["Name"]).drop_duplicates(
+                subset=["Name"], keep="last"
+            )
+            intensity_name_table = intensity_name_table.set_index("Name")
+            intensity_peakid_table = consensus_intensity[["PeakId", *intensity_cols]].copy()
+            intensity_peakid_table = intensity_peakid_table.dropna(subset=["PeakId"]).drop_duplicates(
+                subset=["PeakId"], keep="last"
+            )
+            intensity_peakid_table = intensity_peakid_table.set_index("PeakId")
+
+            intensity_covariates = intensity_name_table.reindex(counts_df.index)
+            missing_mask = intensity_covariates[intensity_cols].isna().all(axis=1)
+            if missing_mask.any():
+                intensity_covariates.loc[missing_mask, intensity_cols] = intensity_peakid_table.reindex(
+                    counts_df.index[missing_mask]
+                )[intensity_cols].to_numpy()
+            prior_covariates = prior_covariates.join(intensity_covariates, how="left")
     else:
         consensus_prior_weights = pd.Series(0.0, index=counts_df.index, dtype=float)
 
@@ -1452,6 +1474,8 @@ def run_pipeline(
             "WidthZ",
             "OverlapCount",
             "PriorOverlap",
+            "PriorIntensity",
+            "IntZ",
             "prior_weight",
             "p_weighted",
             "q_weighted",

--- a/prior_utils.py
+++ b/prior_utils.py
@@ -247,6 +247,112 @@ class PriorRegistry:
             except Exception:  # pragma: no cover - best effort
                 pass
 
+    def compute_consensus_intensity_z(self, consensus_peaks: pd.DataFrame) -> pd.DataFrame:
+        """Compute per-consensus-peak prior intensity and z-score from ``prior_bigwig``.
+
+        The returned frame always contains ``Name``, ``PeakId``, ``PriorIntensity`` and
+        ``IntZ`` columns. When bigWig support is unavailable, intensity columns are filled
+        with ``NaN`` to keep downstream merges stable.
+        """
+
+        required = {"Chromosome", "Start", "End", "Name"}
+        if consensus_peaks.empty or not required.issubset(consensus_peaks.columns):
+            return pd.DataFrame(columns=["Name", "PeakId", "PriorIntensity", "IntZ"])
+
+        base = consensus_peaks[["Chromosome", "Start", "End", "Name"]].copy().reset_index(drop=True)
+        base["Start"] = pd.to_numeric(base["Start"], errors="coerce")
+        base["End"] = pd.to_numeric(base["End"], errors="coerce")
+        base["PeakId"] = (
+            base["Chromosome"].astype(str)
+            + ":"
+            + base["Start"].fillna(-1).astype(int).astype(str)
+            + "-"
+            + base["End"].fillna(-1).astype(int).astype(str)
+        )
+        base["PriorIntensity"] = np.nan
+        base["IntZ"] = np.nan
+
+        if self.prior_bigwig_path is None:
+            return base[["Name", "PeakId", "PriorIntensity", "IntZ"]]
+        if pyBigWig is None:
+            LOGGER.warning(
+                "pyBigWig not installed; cannot compute per-peak prior intensity from %s",
+                self.prior_bigwig_path,
+            )
+            return base[["Name", "PeakId", "PriorIntensity", "IntZ"]]
+
+        try:
+            handle = pyBigWig.open(str(self.prior_bigwig_path))
+        except Exception as exc:  # pragma: no cover - IO heavy
+            LOGGER.warning("Failed to open prior bigWig %s: %s", self.prior_bigwig_path, exc)
+            return base[["Name", "PeakId", "PriorIntensity", "IntZ"]]
+
+        try:
+            chrom_sizes = handle.chroms() or {}
+            if not chrom_sizes:
+                LOGGER.warning("Prior bigWig %s has no chromosome size metadata", self.prior_bigwig_path)
+                return base[["Name", "PeakId", "PriorIntensity", "IntZ"]]
+
+            values: List[float] = []
+            success = 0
+            for _, row in base.iterrows():
+                chrom = str(row["Chromosome"])
+                start_raw = row["Start"]
+                end_raw = row["End"]
+                value = math.nan
+                if (
+                    chrom in chrom_sizes
+                    and pd.notna(start_raw)
+                    and pd.notna(end_raw)
+                ):
+                    chrom_end = int(chrom_sizes[chrom])
+                    start = max(0, int(start_raw))
+                    end = min(max(start + 1, int(end_raw)), chrom_end)
+                    if end > start:
+                        try:
+                            stat = handle.stats(chrom, start, end, nBins=1, exact=True)[0]
+                        except Exception:
+                            stat = None
+                        if isinstance(stat, (float, int)) and not math.isnan(float(stat)):
+                            value = float(stat)
+                            success += 1
+                values.append(value)
+
+            base["PriorIntensity"] = pd.Series(values, dtype=float)
+            LOGGER.info(
+                "Computed prior intensity for %d/%d consensus peaks from %s",
+                success,
+                len(base),
+                self.prior_bigwig_path,
+            )
+        finally:
+            try:
+                handle.close()
+            except Exception:  # pragma: no cover - best effort
+                pass
+
+        mean = self.distributions.get("intensity_mean")
+        std = self.distributions.get("intensity_std")
+        try:
+            mean_value = float(mean) if mean is not None else math.nan
+        except (TypeError, ValueError):
+            mean_value = math.nan
+        try:
+            std_value = float(std) if std is not None else math.nan
+        except (TypeError, ValueError):
+            std_value = math.nan
+
+        if not np.isfinite(std_value) or std_value == 0 or not np.isfinite(mean_value):
+            LOGGER.warning(
+                "Cannot compute IntZ because prior intensity mean/std are invalid (mean=%s, std=%s)",
+                mean,
+                std,
+            )
+            return base[["Name", "PeakId", "PriorIntensity", "IntZ"]]
+
+        base["IntZ"] = (base["PriorIntensity"] - mean_value) / std_value
+        return base[["Name", "PeakId", "PriorIntensity", "IntZ"]]
+
     # ------------------------------------------------------------------
     # Matching
     # ------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Enable the prior bigWig to provide per-consensus-peak intensity signal so `IntZ` is derived from real per-peak measurements instead of being defaulted to zero.
- Reuse existing `PriorRegistry` distribution statistics to keep the implementation conservative, interpretable and easy to debug.
- Ensure the pipeline remains robust when bigWig/pyBigWig is unavailable by failing gracefully (NaNs and warnings) and not changing CLI or main flow.

### Description
- Added `PriorRegistry.compute_consensus_intensity_z(consensus_peaks: DataFrame) -> DataFrame` in `prior_utils.py` which accepts consensus peaks with `Chromosome/Start/End/Name`, extracts per-peak average signal from `prior_bigwig` (using `pyBigWig` when available), and returns `Name`, `PeakId`, `PriorIntensity`, and `IntZ` columns; if `pyBigWig` or bigWig access is unavailable the function returns the same frame with `PriorIntensity/IntZ` as `NaN` and emits a warning.
- `IntZ` is computed as a standard z-score: `IntZ = (PriorIntensity - intensity_mean) / intensity_std` using `distributions['intensity_mean']` and `distributions['intensity_std']` produced by `load_prior_distributions()`; when `std` or `mean` are invalid (`0`/`NaN`/missing) `IntZ` remains `NaN` and a warning is logged.
- Integrated the per-peak intensity results into `run_pipeline()` in `chipdiff.py` by merging `PriorIntensity` and `IntZ` into `prior_covariates` (matched first by `Name`, then fallback to `PeakId`) and joining these into `prior_adjusted`/`diff_res`, and added `PriorIntensity`/`IntZ` to the retained output columns so they appear in `differential_results.tsv` and `differential_results_prior.tsv` when available.
- Added informative logging: counts of successfully computed peak intensities and warnings when `pyBigWig` is missing, bigWig cannot be opened, or distribution stats are invalid; no new dependencies were added and CLI parameter names and main flow structure were preserved.

### Testing
- Ran Python byte-compile check: `python -m py_compile prior_utils.py chipdiff.py`, which succeeded.
- No additional automated unit tests were available in the repository; changes were coded to be defensive and to log warnings rather than raise on missing optional support (e.g., missing `pyBigWig` or unreadable bigWig).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab9f4ddca0832798b8f658f575ec60)