### PR TITLE
Clarify prior semantics, docs, and add lightweight prior-weighting tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,25 +246,45 @@ threading controls, annotation, enrichment, priors, and metadata-sheet helpers (
 
 ## Optional priors (current behaviour)
 
-Priors are supported but intentionally conservative in the current release:
+Priors are used as **external covariates** for weighted multiple-testing correction, not as replacements for core differential statistics.
 
-- **What gets loaded** – You can pass a BED (`--prior-bed`), bigWig (`--prior-bigwig`), and shape statistics table
-  (`--prior-stats`), either directly or through `--prior-manifest`. The registry records width distributions, optional
-  intensity summaries, and shape statistics for later plotting.
+### What priors do (and do not do)
+- Priors **do not** modify raw `log2FoldChange`.
+- Priors **do not** modify raw `pvalue`.
+- Priors **do** affect weighted BH outputs (`prior_weight`, `p_weighted`, `q_weighted`), which can change ranking and significance calls.
 
-- **How they are applied** – The BED overlap determines `PriorOverlap` and a per-peak `PriorWeight` (with a novelty penalty for
-  unusually wide novel peaks). During differential testing, those overlap-aware weights are blended with any per-peak `IntZ`
-  (intensity z) and `ShapeZ` (shape z) columns to form a unified score; the score is standardised, exponentiated, normalised to
-  mean 1, and fed into the weighted Benjamini–Hochberg procedure (`prior_weight`, `p_weighted`, `q_weighted`). Log fold-changes
-  and raw p-values are not directly altered.
+### Prior inputs and their roles
+- `--prior-bed`: provides overlap/matching information and width context, producing covariates such as `PriorWeight`, `NoveltyPenalty`, and `WidthZ`.
+- `--prior-bigwig`: provides reference signal intensity context, yielding per-peak `PriorIntensity` and `IntZ`.
+- `--shape-tsv`: provides external peak-shape covariates aligned to consensus peaks (for example `ShapeZ`).
+- `--prior-manifest`: bundles prior resources (commonly `prior_bed`, `prior_bigwig`, `prior_stats`, `prior_weight`) into one reusable config.
 
-- **Why use them** – Overlap with a trusted catalogue down-weights p-values for familiar loci, while high-magnitude
-  intensity/shape deviations (if supplied) push weights back toward 1, reducing over-confidence in discordant peaks. QC
-  artefacts are still summarised (distributions, KDE plots, overlap tables), but the priors also influence multiple-testing
-  correction through the weighting scheme rather than serving purely as quality checks.
+### Minimal prior usage example
+```bash
+./peakforge tsvmode example/data/metadata_1v1.tsv \
+  --output-dir results/prior_demo \
+  --prior-bed results/prior_demo/prior_inputs/demo_prior.bed \
+  --prior-bigwig results/prior_demo/prior_inputs/demo_prior.bw \
+  --shape-tsv results/prior_demo/shape/peak_shape_summary.tsv \
+  --prior-weight 0.4
+```
 
-To ship a reusable prior bundle, place the files next to a `prior_manifest.json` containing the keys `prior_bed`,
-`prior_bigwig`, `prior_stats`, and `prior_weight`. `example/run_with_prior.sh` demonstrates this layout end-to-end.
+### When should I use priors?
+Priors are most useful when external evidence exists for where true regulatory signal is likely to occur, especially in low-replicate or borderline-significance settings. Suitable priors should be as close as possible to the current analysis in assay type, cell or tissue context, genome build, and biological state.
+
+### What makes a good prior?
+The best priors are assay-matched and context-matched reference regions, such as public ATAC-seq peaks for ATAC-seq analyses, or matched CUT&Tag / ChIP peaks for the same target. DNase-seq peaks can also be used as a weaker prior for ATAC-seq because both assays capture open chromatin, but assay-matched ATAC priors are preferred.
+
+### Can CUT&Tag priors be used for ATAC-seq?
+Sometimes. CUT&Tag priors are most reasonable when the profiled mark or factor is expected to co-localize with accessible regulatory elements, such as active promoter/enhancer marks. They should be used cautiously and interpreted as functional-regulatory priors rather than generic accessibility priors.
+
+### Should priors come from treatment or control samples?
+In most cases, priors should be neutral and not strongly biased toward one comparison arm. We recommend using pooled, consensus, or independent reference peak sets rather than priors derived exclusively from only treatment or only control samples.
+
+### What priors do not do
+Priors in PeakForge do not modify the raw log2 fold-change or the raw p-value. Instead, priors are used as external covariates for weighted multiple-testing correction, which can improve ranking and prioritization of peaks supported by prior knowledge.
+
+To ship a reusable prior bundle, place files next to a `prior_manifest.json` with keys such as `prior_bed`, `prior_bigwig`, `prior_stats`, and `prior_weight`. `example/run_with_prior.sh` demonstrates this layout end-to-end.
 
 ---
 

--- a/chipdiff.py
+++ b/chipdiff.py
@@ -636,12 +636,18 @@ def benjamini_hochberg(pvalues: pd.Series) -> pd.Series:
 
 
 def compute_prior_score(df):
-    """
-    Compute unified prior score from available covariates.
+    """Build a unified prior score from covariates used by weighted BH.
 
-    Keep compatibility with historical inputs that only provide boolean
-    ``PriorOverlap`` while preferring continuous covariates when present.
-    Returns a numpy array S_i: unified prior scores.
+    Covariate groups are intentionally separated:
+      1) Matching/similarity covariates from prior overlap context
+         (``PriorWeight``, ``NoveltyPenalty``, ``PriorOverlap`` fallback).
+      2) Deviation-from-prior-distribution covariates
+         (``IntZ`` from prior bigWig, ``ShapeZ`` from shape priors).
+
+    These inputs are combined into ``S_i`` and later mapped to final weighted-BH
+    quantities (``prior_weight``, ``p_weighted``, ``q_weighted``). Raw ``pvalue``
+    and ``log2FoldChange`` are *not* modified here.
+
     Default formula:
         S_i = 2.0 * PriorWeight
               - 1.0 * NoveltyPenalty
@@ -841,13 +847,26 @@ def load_shape_covariates(shape_tsv: Path, peak_index: pd.Index, consensus_df: p
 
 
 def weighted_bh(p_values, weights, alpha=0.05):
-    """
-    p_values: raw p-values (unchanged)
-    weights: normalized weights from compute_prior_weights
-    Returns:
-        p_weighted: p / w   (clipped at 1)
-        q_weighted: BH-adjusted q-values on p_weighted
-        significant: boolean array for FDR alpha
+    """Weighted Benjamini-Hochberg over raw p-values.
+
+    Parameters
+    ----------
+    p_values
+        Raw p-values from differential testing (input values are unchanged).
+    weights
+        Positive per-peak weighted-FDR multipliers from ``compute_prior_weights``.
+
+    Returns
+    -------
+    p_weighted
+        ``p / w`` (clipped to [0, 1]) used as BH input.
+    q_weighted
+        BH-adjusted q-values computed on ``p_weighted``.
+    significant
+        Boolean mask ``q_weighted <= alpha``.
+
+    Note: this step affects multiple-testing ranking/significance only;
+    raw ``log2FoldChange`` and raw ``pvalue`` columns remain untouched.
     """
 
     pvals = np.asarray(p_values, dtype=float)
@@ -1360,6 +1379,9 @@ def run_pipeline(
             path = (manifest_dir / path).expanduser()
         return path
 
+    # Prior resources feed three layers: (a) matching covariates from BED overlap,
+    # (b) distribution-deviation covariates such as IntZ/ShapeZ, and (c) final
+    # weighted-BH outputs computed later from the combined covariates.
     prior_bed_path = _normalise_path(getattr(args, "prior_bed", None))
     if prior_bed_path is None:
         prior_bed_path = _normalise_path(_manifest_lookup("prior_bed", "bed", "peaks"))
@@ -1600,6 +1622,9 @@ def run_pipeline(
         if "ShapeZ" not in prior_adjusted.columns:
             prior_adjusted["ShapeZ"] = 0.0
 
+        # Final weighted multiple-testing layer: these are *not* the same as
+        # registry-level PriorWeight (matching covariate). The output ``prior_weight``
+        # below is the normalized weighted-BH multiplier derived from all covariates.
         weights = compute_prior_weights(prior_adjusted)
         p_weighted, q_weighted, sig = weighted_bh(
             prior_adjusted["pvalue"].to_numpy(), weights, alpha=0.05
@@ -1828,7 +1853,10 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         "--prior-weight",
         type=float,
         default=0.3,
-        help="Strength of the prior regularisation (0 disables influence)",
+        help=(
+            "Global prior influence for covariate construction and weighted-BH "
+            "reweighting only (does not change raw log2FC or raw p-values; 0 disables)"
+        ),
     )
     parser.add_argument(
         "--threads",

--- a/prior_utils.py
+++ b/prior_utils.py
@@ -72,7 +72,15 @@ class _ShapeStat:
 
 
 class PriorRegistry:
-    """Utility class that coordinates the use of public priors."""
+    """Utility class that coordinates external priors and prior-derived covariates.
+
+    The registry exposes **matching/similarity covariates** used upstream of weighted FDR,
+    including ``PriorWeight`` and ``NoveltyPenalty`` from BED overlap and width context.
+    Additional **distribution-deviation covariates** (for example ``IntZ`` from bigWig
+    intensity and ``ShapeZ`` from shape statistics) are computed elsewhere and merged later.
+    Final multiple-testing weights (``prior_weight``/``p_weighted``/``q_weighted``) are
+    produced in ``chipdiff.py`` and intentionally kept separate from registry fields.
+    """
 
     def __init__(
         self,
@@ -392,6 +400,10 @@ class PriorRegistry:
             overlap_count = counts_df["NumberOverlaps"].reindex(base.index).fillna(0).astype(int)
             overlap = overlap_count > 0
 
+        # Similarity/matching covariates derived from BED context:
+        # - PriorWeight: overlap-aware support strength in [0, self.weight]
+        # - NoveltyPenalty: penalty for non-overlapping peaks with unusual width
+        # - WidthZ: signed deviation from prior BED width distribution
         abs_z = np.abs(width_z.fillna(0.0).to_numpy())
         novelty_penalty_values = np.clip(abs_z, 0, 6) * self.weight
         novelty_penalty_values = np.where(overlap.to_numpy(), 0.0, novelty_penalty_values)

--- a/tests/test_prior_weighting.py
+++ b/tests/test_prior_weighting.py
@@ -1,0 +1,77 @@
+import numpy as np
+import pandas as pd
+
+from chipdiff import compute_prior_weights, weighted_bh, load_shape_covariates
+from prior_utils import PriorRegistry
+
+
+def test_weighted_bh_shape_and_range():
+    p = np.array([0.001, 0.02, 0.2, 0.8], dtype=float)
+    w = np.array([1.2, 1.0, 0.8, 1.0], dtype=float)
+    p_w, q_w, sig = weighted_bh(p, w, alpha=0.05)
+    assert len(p_w) == len(p)
+    assert len(q_w) == len(p)
+    assert len(sig) == len(p)
+    assert np.all((p_w >= 0) & (p_w <= 1))
+    assert np.all((q_w >= 0) & (q_w <= 1))
+
+
+def test_no_prior_like_behavior_when_covariates_missing():
+    df = pd.DataFrame({"pvalue": [0.01, 0.2, 0.8]})
+    w = compute_prior_weights(df)
+    assert np.allclose(w, np.ones(len(df)))
+
+
+def test_prior_bed_covariates_only():
+    peaks = pd.DataFrame(
+        {
+            "Chromosome": ["chr1", "chr1"],
+            "Start": [100, 400],
+            "End": [200, 500],
+        }
+    )
+    reg = PriorRegistry(weight=0.3)
+    reg.distributions["width_mean"] = 100.0
+    reg.distributions["width_std"] = 10.0
+    out = reg.match_prior(peaks)
+    assert {"PriorWeight", "NoveltyPenalty", "WidthZ", "PriorOverlap"}.issubset(out.columns)
+
+
+def test_prior_bed_plus_bigwig_covariates_placeholder_without_file():
+    consensus = pd.DataFrame(
+        {
+            "Chromosome": ["chr1"],
+            "Start": [100],
+            "End": [200],
+            "Name": ["peak_1"],
+        }
+    )
+    reg = PriorRegistry(prior_bigwig="/non/existing/file.bw", weight=0.3)
+    out = reg.compute_consensus_intensity_z(consensus)
+    assert set(["Name", "PeakId", "PriorIntensity", "IntZ"]).issubset(out.columns)
+    assert len(out) == 1
+
+
+def test_prior_bed_plus_shape_tsv_merge_tolerates_unmatched_rows(tmp_path):
+    tsv = tmp_path / "shape.tsv"
+    pd.DataFrame(
+        {
+            "peak_id": ["chr1:10-20"],
+            "ShapeZ": [1.5],
+        }
+    ).to_csv(tsv, sep="\t", index=False)
+
+    peak_index = pd.Index(["chr1:999-1999"])  # unmatched on purpose
+    consensus_df = pd.DataFrame(
+        {
+            "Name": ["peak_unmatched"],
+            "Chromosome": ["chr1"],
+            "Start": [999],
+            "End": [1999],
+        },
+        index=peak_index,
+    )
+    merged = load_shape_covariates(tsv, peak_index, consensus_df)
+    assert len(merged) == 1
+    assert "ShapeZ" in merged.columns
+    assert merged["ShapeZ"].isna().all()


### PR DESCRIPTION
### Motivation
- Clarify how priors are used so users understand what is and is not modified during analysis, separating overlap/matching signals from distribution-deviation signals and from final weighted-BH outputs.
- Improve help text and README so `--prior-weight` and prior inputs (`--prior-bed`, `--prior-bigwig`, `--shape-tsv` / manifest) are unambiguous and aligned with implementation.
- Provide a small set of executable test drafts that exercise weighted-BH, registry covariate generation and merge-tolerance without introducing major refactors.

### Description
- Added explanatory docstring/comments to `PriorRegistry` and `match_prior` to distinguish matching/similarity covariates (`PriorWeight`, `NoveltyPenalty`, `WidthZ`), distribution-deviation covariates (`IntZ`, `ShapeZ`), and final weighted-BH outputs (`prior_weight`, `p_weighted`, `q_weighted`).
- Updated `compute_prior_score` and `weighted_bh` docstrings to make it explicit that raw `log2FoldChange` and raw `pvalue` are not modified and that weighted BH only affects ranking/significance; inserted clarifying comments near `run_pipeline` where priors are loaded and used.
- Clarified CLI help for `--prior-weight` to state it only controls covariate construction and weighted-FDR reweighting (does not change raw statistics), and fixed README to document prior roles, usage guidance, a minimal usage example, and to replace the inconsistent `--prior-stats` mention with the actual `--shape-tsv` / manifest behavior.
- Added lightweight pytest-style tests in `tests/test_prior_weighting.py` covering `weighted_bh` output shape/ranges, default/no-prior behavior, `PriorRegistry.match_prior` covariates, placeholder handling for missing bigWig, and tolerance for unmatched `shape` TSV merges; no large code abstractions or file-structure changes were made.

### Testing
- Ran Python byte-compile on the modified modules with `python -m py_compile chipdiff.py prior_utils.py tests/test_prior_weighting.py`, which completed successfully.
- Ran `python -m pytest -q` in this environment but test collection failed due to missing runtime dependency (`numpy`), so tests could not be executed here (this is an environment issue, not a code failure).
- The added tests are lightweight and intended to pass in CI or a developer environment where `numpy`/`pandas` are installed; they exercise the major prior-integration code paths without requiring external files or tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aba3c6fab4832791cd86053fc3143a)